### PR TITLE
Enhance the performance of IMQ

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,7 +1,7 @@
 IMQ changelog:
 --------------
 2015-06-25
-		Feng Gao add one new parameter of IMQ module(4.0), imq_dev_accurate_stats (default is 1).
+		Feng Gao add one new parameter of IMQ module(3.18,4.0,and 4.1), imq_dev_accurate_stats (default is 1).
 		It is used to notify if IMQ get the accurate stats. 
 		When imq_dev_accurate_stats is 0, it could avoid one spin to enhance the performance.
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,10 @@
 IMQ changelog:
 --------------
+2015-06-25
+		Feng Gao add one new parameter of IMQ module(4.0), imq_dev_accurate_stats (default is 1).
+		It is used to notify if IMQ get the accurate stats. 
+		When imq_dev_accurate_stats is 0, it could avoid one spin to enhance the performance.
+
 2015-06-24
 		Feng Gao removed usless skb_cb_store_lock of 4.0 patch. It will be merged into other patches if it is ok.
 		Fixed malformed linux-3.2-imq.diff, linux-3.10-imq.diff, linux-3.12-imq.diff

--- a/kernel/v3.x/linux-3.18-imq.diff
+++ b/kernel/v3.x/linux-3.18-imq.diff
@@ -142,10 +142,10 @@ index 61aefdd..41be5b8 100644
  obj-$(CONFIG_MII) += mii.o
 diff --git a/drivers/net/imq.c b/drivers/net/imq.c
 new file mode 100644
-index 0000000..ab07499
+index 0000000..90b0148
 --- /dev/null
 +++ b/drivers/net/imq.c
-@@ -0,0 +1,898 @@
+@@ -0,0 +1,901 @@
 +/*
 + *             Pseudo-driver for the intermediate queue device.
 + *
@@ -254,6 +254,7 @@ index 0000000..ab07499
 +#define IMQ_MAX_QUEUES 32
 +static int numqueues = 1;
 +static u32 imq_hashrnd;
++static int imq_dev_accurate_stats = 1;
 +
 +static inline __be16 pppoe_proto(const struct sk_buff *skb)
 +{
@@ -794,13 +795,13 @@ index 0000000..ab07499
 +				IMQ device will not be frozen or stoped, and it always be successful.
 +				So we need not check its status and return value to accelerate.
 +				*/
-+				if (unlikely(txq->xmit_lock_owner == cpu)) {
-+					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
-+				} else {
++				if (imq_dev_accurate_stats && txq->xmit_lock_owner != cpu) {
 +					HARD_TX_LOCK(dev, txq, cpu);
 +					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
 +					HARD_TX_UNLOCK(dev, txq);
-+				}
++				} else {
++					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
++				} 
 +			}
 +		}
 +#endif
@@ -1001,8 +1002,8 @@ index 0000000..ab07499
 +		return err;
 +	}
 +
-+	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d)\n",
-+		numdevs, numqueues);
++	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d, imq_dev_accurate_stats = %d)\n",
++		numdevs, numqueues, imq_dev_accurate_stats);
 +
 +#if defined(CONFIG_IMQ_BEHAVIOR_BA) || defined(CONFIG_IMQ_BEHAVIOR_BB)
 +	pr_info("\tHooking IMQ before NAT on PREROUTING.\n");
@@ -1042,8 +1043,10 @@ index 0000000..ab07499
 +
 +module_param(numdevs, int, 0);
 +module_param(numqueues, int, 0);
++module_param(imq_dev_accurate_stats, int, 0);
 +MODULE_PARM_DESC(numdevs, "number of IMQ devices (how many imq* devices will be created)");
 +MODULE_PARM_DESC(numqueues, "number of queues per IMQ device");
++MODULE_PARM_DESC(imq_dev_accurate_stats, "Notify if need the accurate imq device stats");
 diff --git a/include/linux/imq.h b/include/linux/imq.h
 new file mode 100644
 index 0000000..1babb09
@@ -1289,10 +1292,10 @@ index 5cdbc1b..19fd9f0 100644
  static void qdisc_pkt_len_init(struct sk_buff *skb)
  {
 diff --git a/net/core/skbuff.c b/net/core/skbuff.c
-index 02ebb71..5275d94 100644
+index 02ebb71..5f33f3f 100644
 --- a/net/core/skbuff.c
 +++ b/net/core/skbuff.c
-@@ -77,6 +77,87 @@
+@@ -77,6 +77,79 @@
  
  struct kmem_cache *skbuff_head_cache __read_mostly;
  static struct kmem_cache *skbuff_fclone_cache __read_mostly;
@@ -1307,8 +1310,6 @@ index 02ebb71..5275d94 100644
 +	void            *cb_next;
 +	atomic_t        refcnt;
 +};
-+
-+static DEFINE_SPINLOCK(skb_cb_store_lock);
 +
 +int skb_save_cb(struct sk_buff *skb)
 +{
@@ -1344,12 +1345,8 @@ index 02ebb71..5275d94 100644
 +	memcpy(skb->cb, next->cb, sizeof(skb->cb));
 +	skb->cb_next = next->cb_next;
 +
-+	spin_lock(&skb_cb_store_lock);
-+
 +	if (atomic_dec_and_test(&next->refcnt))
 +		kmem_cache_free(skbuff_cb_store_cache, next);
-+
-+	spin_unlock(&skb_cb_store_lock);
 +
 +	return 0;
 +}
@@ -1365,22 +1362,20 @@ index 02ebb71..5275d94 100644
 +		return;
 +	}
 +
-+	spin_lock(&skb_cb_store_lock);
-+
 +	old = (struct sk_buff *)__old;
 +
 +	next = old->cb_next;
 +	atomic_inc(&next->refcnt);
++	wmb();
 +	new->cb_next = next;
 +
-+	spin_unlock(&skb_cb_store_lock);
 +}
 +#endif
 +
  
  /**
   *	skb_panic - private function for out-of-line support
-@@ -591,6 +672,28 @@ static void skb_release_head_state(struct sk_buff *skb)
+@@ -591,6 +664,28 @@ static void skb_release_head_state(struct sk_buff *skb)
  		WARN_ON(in_irq());
  		skb->destructor(skb);
  	}
@@ -1409,7 +1404,7 @@ index 02ebb71..5275d94 100644
  #if IS_ENABLED(CONFIG_NF_CONNTRACK)
  	nf_conntrack_put(skb->nfct);
  #endif
-@@ -715,6 +818,10 @@ static void __copy_skb_header(struct sk_buff *new, const struct sk_buff *old)
+@@ -715,6 +810,10 @@ static void __copy_skb_header(struct sk_buff *new, const struct sk_buff *old)
  	/* We do not copy old->sk */
  	new->dev		= old->dev;
  	memcpy(new->cb, old->cb, sizeof(old->cb));
@@ -1420,7 +1415,7 @@ index 02ebb71..5275d94 100644
  	skb_dst_copy(new, old);
  #ifdef CONFIG_XFRM
  	new->sp			= secpath_get(old->sp);
-@@ -3280,6 +3387,13 @@ void __init skb_init(void)
+@@ -3280,6 +3379,13 @@ void __init skb_init(void)
  						0,
  						SLAB_HWCACHE_ALIGN|SLAB_PANIC,
  						NULL);

--- a/kernel/v4.x/linux-4.0-imq.diff
+++ b/kernel/v4.x/linux-4.0-imq.diff
@@ -1,5 +1,5 @@
 diff --git a/drivers/net/Kconfig b/drivers/net/Kconfig
-index df51d60..d3db495 100644
+index df51d60..e937550 100644
 --- a/drivers/net/Kconfig
 +++ b/drivers/net/Kconfig
 @@ -220,6 +220,125 @@ config RIONET_RX_SIZE
@@ -142,10 +142,10 @@ index e25fdd7..b411742 100644
  obj-$(CONFIG_MII) += mii.o
 diff --git a/drivers/net/imq.c b/drivers/net/imq.c
 new file mode 100644
-index 0000000..53ea50a
+index 0000000..6692f5d
 --- /dev/null
 +++ b/drivers/net/imq.c
-@@ -0,0 +1,1047 @@
+@@ -0,0 +1,900 @@
 +/*
 + *             Pseudo-driver for the intermediate queue device.
 + *
@@ -254,6 +254,7 @@ index 0000000..53ea50a
 +#define IMQ_MAX_QUEUES 32
 +static int numqueues = 1;
 +static u32 imq_hashrnd;
++static int imq_dev_accurate_stats = 1;
 +
 +static inline __be16 pppoe_proto(const struct sk_buff *skb)
 +{
@@ -787,16 +788,16 @@ index 0000000..53ea50a
 +				int cpu = smp_processor_id(); /* ok because BHs are off */
 +
 +				txq = skb_get_tx_queue(dev, skb_popd);
-+				if (unlikely(txq->xmit_lock_owner == cpu)) {
-+					if (!netif_xmit_frozen_or_stopped(txq)) {
-+						dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
-+					}
-+				} else {
++				/*
++				We need not check the frozen/stop state of IMQ device.
++				Because the imq device never frozen and stop
++ 				*/
++				if (imq_dev_accurate_stats && txq->xmit_lock_owner != cpu) {
 +					HARD_TX_LOCK(dev, txq, cpu);
-+					if (!netif_xmit_frozen_or_stopped(txq)) {
-+						dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
-+					}
++					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
 +					HARD_TX_UNLOCK(dev, txq);
++				} else {
++					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
 +				}
 +			}
 +		}
@@ -996,8 +997,8 @@ index 0000000..53ea50a
 +		return err;
 +	}
 +
-+	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d)\n",
-+		numdevs, numqueues);
++	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d, imq_dev_accurate_stats = %d)\n",
++		numdevs, numqueues, imq_dev_accurate_stats);
 +
 +#if defined(CONFIG_IMQ_BEHAVIOR_BA) || defined(CONFIG_IMQ_BEHAVIOR_BB)
 +	pr_info("\tHooking IMQ before NAT on PREROUTING.\n");
@@ -1037,13 +1038,14 @@ index 0000000..53ea50a
 +
 +module_param(numdevs, int, 0);
 +module_param(numqueues, int, 0);
++module_param(imq_dev_accurate_stats, int, 0);
 +MODULE_PARM_DESC(numdevs, "number of IMQ devices (how many imq* devices will be created)");
 +MODULE_PARM_DESC(numqueues, "number of queues per IMQ device");
++MODULE_PARM_DESC(imq_dev_accurate_stats, "Notify if need the accurate imq device stats");
 +MODULE_AUTHOR("https://github.com/imq/linuximq");
 +MODULE_DESCRIPTION("Pseudo-driver for the intermediate queue device. See https://github.com/imq/linuximq for more information.");
 +MODULE_LICENSE("GPL");
 +MODULE_ALIAS_RTNL_LINK("imq");
-+
 diff --git a/include/linux/imq.h b/include/linux/imq.h
 new file mode 100644
 index 0000000..1babb09
@@ -1567,7 +1569,7 @@ index 4c8b68e..45b0daa 100644
  				goto next_hook;
 diff --git a/net/netfilter/xt_IMQ.c b/net/netfilter/xt_IMQ.c
 new file mode 100644
-index 0000000..1c3cd66
+index 0000000..f9c5817
 --- /dev/null
 +++ b/net/netfilter/xt_IMQ.c
 @@ -0,0 +1,72 @@

--- a/kernel/v4.x/linux-4.1-imq.diff
+++ b/kernel/v4.x/linux-4.1-imq.diff
@@ -1,5 +1,5 @@
 diff --git a/drivers/net/Kconfig b/drivers/net/Kconfig
-index df51d60..d3db495 100644
+index df51d60..e937550 100644
 --- a/drivers/net/Kconfig
 +++ b/drivers/net/Kconfig
 @@ -220,6 +220,125 @@ config RIONET_RX_SIZE
@@ -142,10 +142,10 @@ index e25fdd7..b411742 100644
  obj-$(CONFIG_MII) += mii.o
 diff --git a/drivers/net/imq.c b/drivers/net/imq.c
 new file mode 100644
-index 0000000..1f160c2
+index 0000000..b010f39
 --- /dev/null
 +++ b/drivers/net/imq.c
-@@ -0,0 +1,1049 @@
+@@ -0,0 +1,903 @@
 +/*
 + *             Pseudo-driver for the intermediate queue device.
 + *
@@ -254,6 +254,7 @@ index 0000000..1f160c2
 +#define IMQ_MAX_QUEUES 32
 +static int numqueues = 1;
 +static u32 imq_hashrnd;
++static int imq_dev_accurate_stats = 1;
 +
 +static inline __be16 pppoe_proto(const struct sk_buff *skb)
 +{
@@ -795,12 +796,12 @@ index 0000000..1f160c2
 +				IMQ device will not be frozen or stoped, and it always be successful.
 +				So we need not check its status and return value to accelerate.
 +				*/
-+				if (unlikely(txq->xmit_lock_owner == cpu)) {
-+					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
-+				} else {
++				if (imq_dev_accurate_stats && txq->xmit_lock_owner != cpu) {
 +					HARD_TX_LOCK(dev, txq, cpu);
 +					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
 +					HARD_TX_UNLOCK(dev, txq);
++				} else {
++					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
 +				}
 +			}
 +		}
@@ -998,8 +999,8 @@ index 0000000..1f160c2
 +		return err;
 +	}
 +
-+	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d)\n",
-+		numdevs, numqueues);
++	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d, imq_dev_accurate_stats = %d)\n",
++		numdevs, numqueues, imq_dev_accurate_stats);
 +
 +#if defined(CONFIG_IMQ_BEHAVIOR_BA) || defined(CONFIG_IMQ_BEHAVIOR_BB)
 +	pr_info("\tHooking IMQ before NAT on PREROUTING.\n");
@@ -1039,13 +1040,15 @@ index 0000000..1f160c2
 +
 +module_param(numdevs, int, 0);
 +module_param(numqueues, int, 0);
++module_param(imq_dev_accurate_stats, int, 0);
 +MODULE_PARM_DESC(numdevs, "number of IMQ devices (how many imq* devices will be created)");
 +MODULE_PARM_DESC(numqueues, "number of queues per IMQ device");
++MODULE_PARM_DESC(imq_dev_accurate_stats, "Notify if need the accurate imq device stats");
++
 +MODULE_AUTHOR("http://https://github.com/imq/linuximq");
 +MODULE_DESCRIPTION("Pseudo-driver for the intermediate queue device. See https://github.com/imq/linuximq/wiki for more information.");
 +MODULE_LICENSE("GPL");
 +MODULE_ALIAS_RTNL_LINK("imq");
-+
 diff --git a/include/linux/imq.h b/include/linux/imq.h
 new file mode 100644
 index 0000000..1babb09
@@ -1601,7 +1604,7 @@ index 2e88032..8524715 100644
  				goto next_hook;
 diff --git a/net/netfilter/xt_IMQ.c b/net/netfilter/xt_IMQ.c
 new file mode 100644
-index 0000000..1c3cd66
+index 0000000..86d7b84
 --- /dev/null
 +++ b/net/netfilter/xt_IMQ.c
 @@ -0,0 +1,72 @@

--- a/latest/linux-3.18-imq.diff
+++ b/latest/linux-3.18-imq.diff
@@ -142,10 +142,10 @@ index 61aefdd..41be5b8 100644
  obj-$(CONFIG_MII) += mii.o
 diff --git a/drivers/net/imq.c b/drivers/net/imq.c
 new file mode 100644
-index 0000000..ab07499
+index 0000000..90b0148
 --- /dev/null
 +++ b/drivers/net/imq.c
-@@ -0,0 +1,898 @@
+@@ -0,0 +1,901 @@
 +/*
 + *             Pseudo-driver for the intermediate queue device.
 + *
@@ -254,6 +254,7 @@ index 0000000..ab07499
 +#define IMQ_MAX_QUEUES 32
 +static int numqueues = 1;
 +static u32 imq_hashrnd;
++static int imq_dev_accurate_stats = 1;
 +
 +static inline __be16 pppoe_proto(const struct sk_buff *skb)
 +{
@@ -794,13 +795,13 @@ index 0000000..ab07499
 +				IMQ device will not be frozen or stoped, and it always be successful.
 +				So we need not check its status and return value to accelerate.
 +				*/
-+				if (unlikely(txq->xmit_lock_owner == cpu)) {
-+					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
-+				} else {
++				if (imq_dev_accurate_stats && txq->xmit_lock_owner != cpu) {
 +					HARD_TX_LOCK(dev, txq, cpu);
 +					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
 +					HARD_TX_UNLOCK(dev, txq);
-+				}
++				} else {
++					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
++				} 
 +			}
 +		}
 +#endif
@@ -1001,8 +1002,8 @@ index 0000000..ab07499
 +		return err;
 +	}
 +
-+	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d)\n",
-+		numdevs, numqueues);
++	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d, imq_dev_accurate_stats = %d)\n",
++		numdevs, numqueues, imq_dev_accurate_stats);
 +
 +#if defined(CONFIG_IMQ_BEHAVIOR_BA) || defined(CONFIG_IMQ_BEHAVIOR_BB)
 +	pr_info("\tHooking IMQ before NAT on PREROUTING.\n");
@@ -1042,8 +1043,10 @@ index 0000000..ab07499
 +
 +module_param(numdevs, int, 0);
 +module_param(numqueues, int, 0);
++module_param(imq_dev_accurate_stats, int, 0);
 +MODULE_PARM_DESC(numdevs, "number of IMQ devices (how many imq* devices will be created)");
 +MODULE_PARM_DESC(numqueues, "number of queues per IMQ device");
++MODULE_PARM_DESC(imq_dev_accurate_stats, "Notify if need the accurate imq device stats");
 diff --git a/include/linux/imq.h b/include/linux/imq.h
 new file mode 100644
 index 0000000..1babb09
@@ -1289,10 +1292,10 @@ index 5cdbc1b..19fd9f0 100644
  static void qdisc_pkt_len_init(struct sk_buff *skb)
  {
 diff --git a/net/core/skbuff.c b/net/core/skbuff.c
-index 02ebb71..5275d94 100644
+index 02ebb71..5f33f3f 100644
 --- a/net/core/skbuff.c
 +++ b/net/core/skbuff.c
-@@ -77,6 +77,87 @@
+@@ -77,6 +77,79 @@
  
  struct kmem_cache *skbuff_head_cache __read_mostly;
  static struct kmem_cache *skbuff_fclone_cache __read_mostly;
@@ -1307,8 +1310,6 @@ index 02ebb71..5275d94 100644
 +	void            *cb_next;
 +	atomic_t        refcnt;
 +};
-+
-+static DEFINE_SPINLOCK(skb_cb_store_lock);
 +
 +int skb_save_cb(struct sk_buff *skb)
 +{
@@ -1344,12 +1345,8 @@ index 02ebb71..5275d94 100644
 +	memcpy(skb->cb, next->cb, sizeof(skb->cb));
 +	skb->cb_next = next->cb_next;
 +
-+	spin_lock(&skb_cb_store_lock);
-+
 +	if (atomic_dec_and_test(&next->refcnt))
 +		kmem_cache_free(skbuff_cb_store_cache, next);
-+
-+	spin_unlock(&skb_cb_store_lock);
 +
 +	return 0;
 +}
@@ -1365,22 +1362,20 @@ index 02ebb71..5275d94 100644
 +		return;
 +	}
 +
-+	spin_lock(&skb_cb_store_lock);
-+
 +	old = (struct sk_buff *)__old;
 +
 +	next = old->cb_next;
 +	atomic_inc(&next->refcnt);
++	wmb();
 +	new->cb_next = next;
 +
-+	spin_unlock(&skb_cb_store_lock);
 +}
 +#endif
 +
  
  /**
   *	skb_panic - private function for out-of-line support
-@@ -591,6 +672,28 @@ static void skb_release_head_state(struct sk_buff *skb)
+@@ -591,6 +664,28 @@ static void skb_release_head_state(struct sk_buff *skb)
  		WARN_ON(in_irq());
  		skb->destructor(skb);
  	}
@@ -1409,7 +1404,7 @@ index 02ebb71..5275d94 100644
  #if IS_ENABLED(CONFIG_NF_CONNTRACK)
  	nf_conntrack_put(skb->nfct);
  #endif
-@@ -715,6 +818,10 @@ static void __copy_skb_header(struct sk_buff *new, const struct sk_buff *old)
+@@ -715,6 +810,10 @@ static void __copy_skb_header(struct sk_buff *new, const struct sk_buff *old)
  	/* We do not copy old->sk */
  	new->dev		= old->dev;
  	memcpy(new->cb, old->cb, sizeof(old->cb));
@@ -1420,7 +1415,7 @@ index 02ebb71..5275d94 100644
  	skb_dst_copy(new, old);
  #ifdef CONFIG_XFRM
  	new->sp			= secpath_get(old->sp);
-@@ -3280,6 +3387,13 @@ void __init skb_init(void)
+@@ -3280,6 +3379,13 @@ void __init skb_init(void)
  						0,
  						SLAB_HWCACHE_ALIGN|SLAB_PANIC,
  						NULL);

--- a/latest/linux-4.0-imq.diff
+++ b/latest/linux-4.0-imq.diff
@@ -1,5 +1,5 @@
 diff --git a/drivers/net/Kconfig b/drivers/net/Kconfig
-index df51d60..d3db495 100644
+index df51d60..e937550 100644
 --- a/drivers/net/Kconfig
 +++ b/drivers/net/Kconfig
 @@ -220,6 +220,125 @@ config RIONET_RX_SIZE
@@ -17,7 +17,7 @@ index df51d60..d3db495 100644
 +	  and distribute bandwidth among them. Iptables is used to specify
 +	  through which IMQ device, if any, packets travel.
 +
-+	  More information at: http://www.linuximq.net/
++	  More information at: https://github.com/imq/linuximq
 +
 +	  To compile this driver as a module, choose M here: the module
 +	  will be called imq.  If unsure, say N.
@@ -45,7 +45,7 @@ index df51d60..d3db495 100644
 +	  This settings are specially usefull when trying to use IMQ
 +	  to shape NATed clients.
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -60,7 +60,7 @@ index df51d60..d3db495 100644
 +	  PREROUTING:   After NAT
 +	  POSTROUTING:  After NAT
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -75,7 +75,7 @@ index df51d60..d3db495 100644
 +	  PREROUTING:   After NAT
 +	  POSTROUTING:  Before NAT
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -90,7 +90,7 @@ index df51d60..d3db495 100644
 +	  PREROUTING:   Before NAT
 +	  POSTROUTING:  After NAT
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -105,7 +105,7 @@ index df51d60..d3db495 100644
 +	  PREROUTING:   Before NAT
 +	  POSTROUTING:  Before NAT
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -121,7 +121,7 @@ index df51d60..d3db495 100644
 +
 +	  The default value is 16.
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -142,10 +142,10 @@ index e25fdd7..b411742 100644
  obj-$(CONFIG_MII) += mii.o
 diff --git a/drivers/net/imq.c b/drivers/net/imq.c
 new file mode 100644
-index 0000000..53ea50a
+index 0000000..6692f5d
 --- /dev/null
 +++ b/drivers/net/imq.c
-@@ -0,0 +1,1047 @@
+@@ -0,0 +1,900 @@
 +/*
 + *             Pseudo-driver for the intermediate queue device.
 + *
@@ -158,156 +158,7 @@ index 0000000..53ea50a
 + *
 + *            The first version was written by Martin Devera, <devik@cdi.cz>
 + *
-+ * Credits:    Jan Rafaj <imq2t@cedric.vabo.cz>
-+ *              - Update patch to 2.4.21
-+ *             Sebastian Strollo <sstrollo@nortelnetworks.com>
-+ *              - Fix "Dead-loop on netdevice imq"-issue
-+ *             Marcel Sebek <sebek64@post.cz>
-+ *              - Update to 2.6.2-rc1
-+ *
-+ *	       After some time of inactivity there is a group taking care
-+ *	       of IMQ again: http://www.linuximq.net
-+ *
-+ *
-+ *	       2004/06/30 - New version of IMQ patch to kernels <=2.6.7
-+ *             including the following changes:
-+ *
-+ *	       - Correction of ipv6 support "+"s issue (Hasso Tepper)
-+ *	       - Correction of imq_init_devs() issue that resulted in
-+ *	       kernel OOPS unloading IMQ as module (Norbert Buchmuller)
-+ *	       - Addition of functionality to choose number of IMQ devices
-+ *	       during kernel config (Andre Correa)
-+ *	       - Addition of functionality to choose how IMQ hooks on
-+ *	       PRE and POSTROUTING (after or before NAT) (Andre Correa)
-+ *	       - Cosmetic corrections (Norbert Buchmuller) (Andre Correa)
-+ *
-+ *
-+ *             2005/12/16 - IMQ versions between 2.6.7 and 2.6.13 were
-+ *             released with almost no problems. 2.6.14-x was released
-+ *             with some important changes: nfcache was removed; After
-+ *             some weeks of trouble we figured out that some IMQ fields
-+ *             in skb were missing in skbuff.c - skb_clone and copy_skb_header.
-+ *             These functions are correctly patched by this new patch version.
-+ *
-+ *             Thanks for all who helped to figure out all the problems with
-+ *             2.6.14.x: Patrick McHardy, Rune Kock, VeNoMouS, Max CtRiX,
-+ *             Kevin Shanahan, Richard Lucassen, Valery Dachev (hopefully
-+ *             I didn't forget anybody). I apologize again for my lack of time.
-+ *
-+ *
-+ *             2008/06/17 - 2.6.25 - Changed imq.c to use qdisc_run() instead
-+ *             of qdisc_restart() and moved qdisc_run() to tasklet to avoid
-+ *             recursive locking. New initialization routines to fix 'rmmod' not
-+ *             working anymore. Used code from ifb.c. (Jussi Kivilinna)
-+ *
-+ *             2008/08/06 - 2.6.26 - (JK)
-+ *              - Replaced tasklet with 'netif_schedule()'.
-+ *              - Cleaned up and added comments for imq_nf_queue().
-+ *
-+ *             2009/04/12
-+ *              - Add skb_save_cb/skb_restore_cb helper functions for backuping
-+ *                control buffer. This is needed because qdisc-layer on kernels
-+ *                2.6.27 and newer overwrite control buffer. (Jussi Kivilinna)
-+ *              - Add better locking for IMQ device. Hopefully this will solve
-+ *                SMP issues. (Jussi Kivilinna)
-+ *              - Port to 2.6.27
-+ *              - Port to 2.6.28
-+ *              - Port to 2.6.29 + fix rmmod not working
-+ *
-+ *             2009/04/20 - (Jussi Kivilinna)
-+ *              - Use netdevice feature flags to avoid extra packet handling
-+ *                by core networking layer and possibly increase performance.
-+ *
-+ *             2009/09/26 - (Jussi Kivilinna)
-+ *              - Add imq_nf_reinject_lockless to fix deadlock with
-+ *                imq_nf_queue/imq_nf_reinject.
-+ *
-+ *             2009/12/08 - (Jussi Kivilinna)
-+ *              - Port to 2.6.32
-+ *              - Add check for skb->nf_queue_entry==NULL in imq_dev_xmit()
-+ *              - Also add better error checking for skb->nf_queue_entry usage
-+ *
-+ *             2010/02/25 - (Jussi Kivilinna)
-+ *              - Port to 2.6.33
-+ *
-+ *             2010/08/15 - (Jussi Kivilinna)
-+ *              - Port to 2.6.35
-+ *              - Simplify hook registration by using nf_register_hooks.
-+ *              - nf_reinject doesn't need spinlock around it, therefore remove
-+ *                imq_nf_reinject function. Other nf_reinject users protect
-+ *                their own data with spinlock. With IMQ however all data is
-+ *                needed is stored per skbuff, so no locking is needed.
-+ *              - Changed IMQ to use 'separate' NF_IMQ_QUEUE instead of
-+ *                NF_QUEUE, this allows working coexistance of IMQ and other
-+ *                NF_QUEUE users.
-+ *              - Make IMQ multi-queue. Number of IMQ device queues can be
-+ *                increased with 'numqueues' module parameters. Default number
-+ *                of queues is 1, in other words by default IMQ works as
-+ *                single-queue device. Multi-queue selection is based on
-+ *                IFB multi-queue patch by Changli Gao <xiaosuo@gmail.com>.
-+ *
-+ *             2011/03/18 - (Jussi Kivilinna)
-+ *              - Port to 2.6.38
-+ *
-+ *             2011/07/12 - (syoder89@gmail.com)
-+ *              - Crash fix that happens when the receiving interface has more
-+ *                than one queue (add missing skb_set_queue_mapping in
-+ *                imq_select_queue).
-+ *
-+ *             2011/07/26 - (Jussi Kivilinna)
-+ *              - Add queue mapping checks for packets exiting IMQ.
-+ *              - Port to 3.0
-+ *
-+ *             2011/08/16 - (Jussi Kivilinna)
-+ *              - Clear IFF_TX_SKB_SHARING flag that was added for linux 3.0.2
-+ *
-+ *             2011/11/03 - Germano Michel <germanomichel@gmail.com>
-+ *              - Fix IMQ for net namespaces
-+ *
-+ *             2011/11/04 - Jussi Kivilinna <jussi.kivilinna@mbnet.fi>
-+ *              - Port to 3.1
-+ *              - Clean-up, move 'get imq device pointer by imqX name' to
-+ *                separate function from imq_nf_queue().
-+ *
-+ *             2012/01/05 - Jussi Kivilinna <jussi.kivilinna@mbnet.fi>
-+ *              - Port to 3.2
-+ *
-+ *             2012/03/19 - Jussi Kivilinna <jussi.kivilinna@mbnet.fi>
-+ *              - Port to 3.3
-+ *
-+ *             2012/12/12 - Jussi Kivilinna <jussi.kivilinna@mbnet.fi>
-+ *              - Port to 3.7
-+ *              - Fix checkpatch.pl warnings
-+ *
-+ *             2013/09/10 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Fixed GSO handling for 3.10, see imq_nf_queue() for comments.
-+ *              - Don't copy skb->cb_next when copying or cloning skbuffs.
-+ *
-+ *             2013/09/16 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.11
-+ *
-+ *             2013/11/12 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.12
-+ *
-+ *             2014/02/07 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.13
-+ *
-+ *             2014/02/16 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.13.3
-+ *
-+ *             2014/04/08 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.14
-+ *
-+ *             2014/06/27 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.15
-+ *
-+ *             2014/08/10 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.16
-+ *
-+ *	       Also, many thanks to pablo Sebastian Greco for making the initial
-+ *	       patch and to those who helped the testing.
-+ *
-+ *             More info at: http://www.linuximq.net/ (Andre Correa)
++ *			   See Credits.txt
 + */
 +
 +#include <linux/module.h>
@@ -403,6 +254,7 @@ index 0000000..53ea50a
 +#define IMQ_MAX_QUEUES 32
 +static int numqueues = 1;
 +static u32 imq_hashrnd;
++static int imq_dev_accurate_stats = 1;
 +
 +static inline __be16 pppoe_proto(const struct sk_buff *skb)
 +{
@@ -936,16 +788,16 @@ index 0000000..53ea50a
 +				int cpu = smp_processor_id(); /* ok because BHs are off */
 +
 +				txq = skb_get_tx_queue(dev, skb_popd);
-+				if (unlikely(txq->xmit_lock_owner == cpu)) {
-+					if (!netif_xmit_frozen_or_stopped(txq)) {
-+						dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
-+					}
-+				} else {
++				/*
++				We need not check the frozen/stop state of IMQ device.
++				Because the imq device never frozen and stop
++ 				*/
++				if (imq_dev_accurate_stats && txq->xmit_lock_owner != cpu) {
 +					HARD_TX_LOCK(dev, txq, cpu);
-+					if (!netif_xmit_frozen_or_stopped(txq)) {
-+						dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
-+					}
++					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
 +					HARD_TX_UNLOCK(dev, txq);
++				} else {
++					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
 +				}
 +			}
 +		}
@@ -1145,8 +997,8 @@ index 0000000..53ea50a
 +		return err;
 +	}
 +
-+	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d)\n",
-+		numdevs, numqueues);
++	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d, imq_dev_accurate_stats = %d)\n",
++		numdevs, numqueues, imq_dev_accurate_stats);
 +
 +#if defined(CONFIG_IMQ_BEHAVIOR_BA) || defined(CONFIG_IMQ_BEHAVIOR_BB)
 +	pr_info("\tHooking IMQ before NAT on PREROUTING.\n");
@@ -1186,13 +1038,14 @@ index 0000000..53ea50a
 +
 +module_param(numdevs, int, 0);
 +module_param(numqueues, int, 0);
++module_param(imq_dev_accurate_stats, int, 0);
 +MODULE_PARM_DESC(numdevs, "number of IMQ devices (how many imq* devices will be created)");
 +MODULE_PARM_DESC(numqueues, "number of queues per IMQ device");
-+MODULE_AUTHOR("http://www.linuximq.net");
-+MODULE_DESCRIPTION("Pseudo-driver for the intermediate queue device. See http://www.linuximq.net/ for more information.");
++MODULE_PARM_DESC(imq_dev_accurate_stats, "Notify if need the accurate imq device stats");
++MODULE_AUTHOR("https://github.com/imq/linuximq");
++MODULE_DESCRIPTION("Pseudo-driver for the intermediate queue device. See https://github.com/imq/linuximq for more information.");
 +MODULE_LICENSE("GPL");
 +MODULE_ALIAS_RTNL_LINK("imq");
-+
 diff --git a/include/linux/imq.h b/include/linux/imq.h
 new file mode 100644
 index 0000000..1babb09
@@ -1716,7 +1569,7 @@ index 4c8b68e..45b0daa 100644
  				goto next_hook;
 diff --git a/net/netfilter/xt_IMQ.c b/net/netfilter/xt_IMQ.c
 new file mode 100644
-index 0000000..1c3cd66
+index 0000000..f9c5817
 --- /dev/null
 +++ b/net/netfilter/xt_IMQ.c
 @@ -0,0 +1,72 @@
@@ -1786,8 +1639,8 @@ index 0000000..1c3cd66
 +module_init(imq_init);
 +module_exit(imq_fini);
 +
-+MODULE_AUTHOR("http://www.linuximq.net");
-+MODULE_DESCRIPTION("Pseudo-driver for the intermediate queue device. See http://www.linuximq.net/ for more information.");
++MODULE_AUTHOR("https://github.com/imq/linuximq");
++MODULE_DESCRIPTION("Pseudo-driver for the intermediate queue device. See https://github.com/imq/linuximq/wiki for more information.");
 +MODULE_LICENSE("GPL");
 +MODULE_ALIAS("ipt_IMQ");
 +MODULE_ALIAS("ip6t_IMQ");

--- a/latest/linux-4.1-imq.diff
+++ b/latest/linux-4.1-imq.diff
@@ -1,5 +1,5 @@
 diff --git a/drivers/net/Kconfig b/drivers/net/Kconfig
-index df51d60..d3db495 100644
+index df51d60..e937550 100644
 --- a/drivers/net/Kconfig
 +++ b/drivers/net/Kconfig
 @@ -220,6 +220,125 @@ config RIONET_RX_SIZE
@@ -17,7 +17,7 @@ index df51d60..d3db495 100644
 +	  and distribute bandwidth among them. Iptables is used to specify
 +	  through which IMQ device, if any, packets travel.
 +
-+	  More information at: http://www.linuximq.net/
++	  More information at: https://github.com/imq/linuximq
 +
 +	  To compile this driver as a module, choose M here: the module
 +	  will be called imq.  If unsure, say N.
@@ -45,7 +45,7 @@ index df51d60..d3db495 100644
 +	  This settings are specially usefull when trying to use IMQ
 +	  to shape NATed clients.
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -60,7 +60,7 @@ index df51d60..d3db495 100644
 +	  PREROUTING:   After NAT
 +	  POSTROUTING:  After NAT
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -75,7 +75,7 @@ index df51d60..d3db495 100644
 +	  PREROUTING:   After NAT
 +	  POSTROUTING:  Before NAT
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -90,7 +90,7 @@ index df51d60..d3db495 100644
 +	  PREROUTING:   Before NAT
 +	  POSTROUTING:  After NAT
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -105,7 +105,7 @@ index df51d60..d3db495 100644
 +	  PREROUTING:   Before NAT
 +	  POSTROUTING:  Before NAT
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -121,7 +121,7 @@ index df51d60..d3db495 100644
 +
 +	  The default value is 16.
 +
-+	  More information can be found at: www.linuximq.net
++	  More information can be found at: https://github.com/imq/linuximq
 +
 +	  If not sure leave the default settings alone.
 +
@@ -142,10 +142,10 @@ index e25fdd7..b411742 100644
  obj-$(CONFIG_MII) += mii.o
 diff --git a/drivers/net/imq.c b/drivers/net/imq.c
 new file mode 100644
-index 0000000..1f160c2
+index 0000000..b010f39
 --- /dev/null
 +++ b/drivers/net/imq.c
-@@ -0,0 +1,1049 @@
+@@ -0,0 +1,903 @@
 +/*
 + *             Pseudo-driver for the intermediate queue device.
 + *
@@ -158,156 +158,7 @@ index 0000000..1f160c2
 + *
 + *            The first version was written by Martin Devera, <devik@cdi.cz>
 + *
-+ * Credits:    Jan Rafaj <imq2t@cedric.vabo.cz>
-+ *              - Update patch to 2.4.21
-+ *             Sebastian Strollo <sstrollo@nortelnetworks.com>
-+ *              - Fix "Dead-loop on netdevice imq"-issue
-+ *             Marcel Sebek <sebek64@post.cz>
-+ *              - Update to 2.6.2-rc1
-+ *
-+ *	       After some time of inactivity there is a group taking care
-+ *	       of IMQ again: http://www.linuximq.net
-+ *
-+ *
-+ *	       2004/06/30 - New version of IMQ patch to kernels <=2.6.7
-+ *             including the following changes:
-+ *
-+ *	       - Correction of ipv6 support "+"s issue (Hasso Tepper)
-+ *	       - Correction of imq_init_devs() issue that resulted in
-+ *	       kernel OOPS unloading IMQ as module (Norbert Buchmuller)
-+ *	       - Addition of functionality to choose number of IMQ devices
-+ *	       during kernel config (Andre Correa)
-+ *	       - Addition of functionality to choose how IMQ hooks on
-+ *	       PRE and POSTROUTING (after or before NAT) (Andre Correa)
-+ *	       - Cosmetic corrections (Norbert Buchmuller) (Andre Correa)
-+ *
-+ *
-+ *             2005/12/16 - IMQ versions between 2.6.7 and 2.6.13 were
-+ *             released with almost no problems. 2.6.14-x was released
-+ *             with some important changes: nfcache was removed; After
-+ *             some weeks of trouble we figured out that some IMQ fields
-+ *             in skb were missing in skbuff.c - skb_clone and copy_skb_header.
-+ *             These functions are correctly patched by this new patch version.
-+ *
-+ *             Thanks for all who helped to figure out all the problems with
-+ *             2.6.14.x: Patrick McHardy, Rune Kock, VeNoMouS, Max CtRiX,
-+ *             Kevin Shanahan, Richard Lucassen, Valery Dachev (hopefully
-+ *             I didn't forget anybody). I apologize again for my lack of time.
-+ *
-+ *
-+ *             2008/06/17 - 2.6.25 - Changed imq.c to use qdisc_run() instead
-+ *             of qdisc_restart() and moved qdisc_run() to tasklet to avoid
-+ *             recursive locking. New initialization routines to fix 'rmmod' not
-+ *             working anymore. Used code from ifb.c. (Jussi Kivilinna)
-+ *
-+ *             2008/08/06 - 2.6.26 - (JK)
-+ *              - Replaced tasklet with 'netif_schedule()'.
-+ *              - Cleaned up and added comments for imq_nf_queue().
-+ *
-+ *             2009/04/12
-+ *              - Add skb_save_cb/skb_restore_cb helper functions for backuping
-+ *                control buffer. This is needed because qdisc-layer on kernels
-+ *                2.6.27 and newer overwrite control buffer. (Jussi Kivilinna)
-+ *              - Add better locking for IMQ device. Hopefully this will solve
-+ *                SMP issues. (Jussi Kivilinna)
-+ *              - Port to 2.6.27
-+ *              - Port to 2.6.28
-+ *              - Port to 2.6.29 + fix rmmod not working
-+ *
-+ *             2009/04/20 - (Jussi Kivilinna)
-+ *              - Use netdevice feature flags to avoid extra packet handling
-+ *                by core networking layer and possibly increase performance.
-+ *
-+ *             2009/09/26 - (Jussi Kivilinna)
-+ *              - Add imq_nf_reinject_lockless to fix deadlock with
-+ *                imq_nf_queue/imq_nf_reinject.
-+ *
-+ *             2009/12/08 - (Jussi Kivilinna)
-+ *              - Port to 2.6.32
-+ *              - Add check for skb->nf_queue_entry==NULL in imq_dev_xmit()
-+ *              - Also add better error checking for skb->nf_queue_entry usage
-+ *
-+ *             2010/02/25 - (Jussi Kivilinna)
-+ *              - Port to 2.6.33
-+ *
-+ *             2010/08/15 - (Jussi Kivilinna)
-+ *              - Port to 2.6.35
-+ *              - Simplify hook registration by using nf_register_hooks.
-+ *              - nf_reinject doesn't need spinlock around it, therefore remove
-+ *                imq_nf_reinject function. Other nf_reinject users protect
-+ *                their own data with spinlock. With IMQ however all data is
-+ *                needed is stored per skbuff, so no locking is needed.
-+ *              - Changed IMQ to use 'separate' NF_IMQ_QUEUE instead of
-+ *                NF_QUEUE, this allows working coexistance of IMQ and other
-+ *                NF_QUEUE users.
-+ *              - Make IMQ multi-queue. Number of IMQ device queues can be
-+ *                increased with 'numqueues' module parameters. Default number
-+ *                of queues is 1, in other words by default IMQ works as
-+ *                single-queue device. Multi-queue selection is based on
-+ *                IFB multi-queue patch by Changli Gao <xiaosuo@gmail.com>.
-+ *
-+ *             2011/03/18 - (Jussi Kivilinna)
-+ *              - Port to 2.6.38
-+ *
-+ *             2011/07/12 - (syoder89@gmail.com)
-+ *              - Crash fix that happens when the receiving interface has more
-+ *                than one queue (add missing skb_set_queue_mapping in
-+ *                imq_select_queue).
-+ *
-+ *             2011/07/26 - (Jussi Kivilinna)
-+ *              - Add queue mapping checks for packets exiting IMQ.
-+ *              - Port to 3.0
-+ *
-+ *             2011/08/16 - (Jussi Kivilinna)
-+ *              - Clear IFF_TX_SKB_SHARING flag that was added for linux 3.0.2
-+ *
-+ *             2011/11/03 - Germano Michel <germanomichel@gmail.com>
-+ *              - Fix IMQ for net namespaces
-+ *
-+ *             2011/11/04 - Jussi Kivilinna <jussi.kivilinna@mbnet.fi>
-+ *              - Port to 3.1
-+ *              - Clean-up, move 'get imq device pointer by imqX name' to
-+ *                separate function from imq_nf_queue().
-+ *
-+ *             2012/01/05 - Jussi Kivilinna <jussi.kivilinna@mbnet.fi>
-+ *              - Port to 3.2
-+ *
-+ *             2012/03/19 - Jussi Kivilinna <jussi.kivilinna@mbnet.fi>
-+ *              - Port to 3.3
-+ *
-+ *             2012/12/12 - Jussi Kivilinna <jussi.kivilinna@mbnet.fi>
-+ *              - Port to 3.7
-+ *              - Fix checkpatch.pl warnings
-+ *
-+ *             2013/09/10 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Fixed GSO handling for 3.10, see imq_nf_queue() for comments.
-+ *              - Don't copy skb->cb_next when copying or cloning skbuffs.
-+ *
-+ *             2013/09/16 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.11
-+ *
-+ *             2013/11/12 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.12
-+ *
-+ *             2014/02/07 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.13
-+ *
-+ *             2014/02/16 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.13.3
-+ *
-+ *             2014/04/08 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.14
-+ *
-+ *             2014/06/27 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.15
-+ *
-+ *             2014/08/10 - Jussi Kivilinna <jussi.kivilinna@iki.fi>
-+ *              - Port to 3.16
-+ *
-+ *	       Also, many thanks to pablo Sebastian Greco for making the initial
-+ *	       patch and to those who helped the testing.
-+ *
-+ *             More info at: http://www.linuximq.net/ (Andre Correa)
++ *			   See Creditis.txt
 + */
 +
 +#include <linux/module.h>
@@ -403,6 +254,7 @@ index 0000000..1f160c2
 +#define IMQ_MAX_QUEUES 32
 +static int numqueues = 1;
 +static u32 imq_hashrnd;
++static int imq_dev_accurate_stats = 1;
 +
 +static inline __be16 pppoe_proto(const struct sk_buff *skb)
 +{
@@ -944,12 +796,12 @@ index 0000000..1f160c2
 +				IMQ device will not be frozen or stoped, and it always be successful.
 +				So we need not check its status and return value to accelerate.
 +				*/
-+				if (unlikely(txq->xmit_lock_owner == cpu)) {
-+					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
-+				} else {
++				if (imq_dev_accurate_stats && txq->xmit_lock_owner != cpu) {
 +					HARD_TX_LOCK(dev, txq, cpu);
 +					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
 +					HARD_TX_UNLOCK(dev, txq);
++				} else {
++					dev_hard_start_xmit(skb_popd, dev, txq, &dummy_ret);
 +				}
 +			}
 +		}
@@ -1147,8 +999,8 @@ index 0000000..1f160c2
 +		return err;
 +	}
 +
-+	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d)\n",
-+		numdevs, numqueues);
++	pr_info("IMQ driver loaded successfully. (numdevs = %d, numqueues = %d, imq_dev_accurate_stats = %d)\n",
++		numdevs, numqueues, imq_dev_accurate_stats);
 +
 +#if defined(CONFIG_IMQ_BEHAVIOR_BA) || defined(CONFIG_IMQ_BEHAVIOR_BB)
 +	pr_info("\tHooking IMQ before NAT on PREROUTING.\n");
@@ -1188,13 +1040,15 @@ index 0000000..1f160c2
 +
 +module_param(numdevs, int, 0);
 +module_param(numqueues, int, 0);
++module_param(imq_dev_accurate_stats, int, 0);
 +MODULE_PARM_DESC(numdevs, "number of IMQ devices (how many imq* devices will be created)");
 +MODULE_PARM_DESC(numqueues, "number of queues per IMQ device");
-+MODULE_AUTHOR("http://www.linuximq.net");
-+MODULE_DESCRIPTION("Pseudo-driver for the intermediate queue device. See http://www.linuximq.net/ for more information.");
++MODULE_PARM_DESC(imq_dev_accurate_stats, "Notify if need the accurate imq device stats");
++
++MODULE_AUTHOR("http://https://github.com/imq/linuximq");
++MODULE_DESCRIPTION("Pseudo-driver for the intermediate queue device. See https://github.com/imq/linuximq/wiki for more information.");
 +MODULE_LICENSE("GPL");
 +MODULE_ALIAS_RTNL_LINK("imq");
-+
 diff --git a/include/linux/imq.h b/include/linux/imq.h
 new file mode 100644
 index 0000000..1babb09
@@ -1750,7 +1604,7 @@ index 2e88032..8524715 100644
  				goto next_hook;
 diff --git a/net/netfilter/xt_IMQ.c b/net/netfilter/xt_IMQ.c
 new file mode 100644
-index 0000000..1c3cd66
+index 0000000..86d7b84
 --- /dev/null
 +++ b/net/netfilter/xt_IMQ.c
 @@ -0,0 +1,72 @@
@@ -1820,8 +1674,8 @@ index 0000000..1c3cd66
 +module_init(imq_init);
 +module_exit(imq_fini);
 +
-+MODULE_AUTHOR("http://www.linuximq.net");
-+MODULE_DESCRIPTION("Pseudo-driver for the intermediate queue device. See http://www.linuximq.net/ for more information.");
++MODULE_AUTHOR("http://https://github.com/imq/linuximq");
++MODULE_DESCRIPTION("Pseudo-driver for the intermediate queue device. See https://github.com/imq/linuximq/wiki for more information.");
 +MODULE_LICENSE("GPL");
 +MODULE_ALIAS("ipt_IMQ");
 +MODULE_ALIAS("ip6t_IMQ");


### PR DESCRIPTION
    Enhance the performance of IMQ
    1. Merge the changes(new module param imq_dev_accurate_stats) to 3.18 and 4.1;
    2. Remove the frozen/stop check of IMQ device when xmit skb;
    3. Remove the skb_cb_store_lock;
